### PR TITLE
[Fix] 服务器参数解析逻辑修复

### DIFF
--- a/backend/src/routers/gachaSimulate.ts
+++ b/backend/src/routers/gachaSimulate.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import { body, validationResult } from 'express-validator';
 import { drawRandomGacha } from '@/view/gachaSimulate';
 import { Gacha, getPresentGachaList } from '@/types/Gacha';
-import { Server } from '@/types/Server';
+import { getServerByServerId, Server } from '@/types/Server';
 import { listToBase64, isServer } from '@/routers/utils';
 
 const router = express.Router();
@@ -34,7 +34,7 @@ router.post(
     const { server_mode, times, compress, gachaId } = req.body;
 
     try {
-      const result = await commandGachaSimulate(server_mode, times, compress, gachaId);
+      const result = await commandGachaSimulate(getServerByServerId(server_mode), times, compress, gachaId);
       res.send(listToBase64(result));
     } catch (e) {
       console.log(e);

--- a/backend/src/routers/searchCard.ts
+++ b/backend/src/routers/searchCard.ts
@@ -4,7 +4,7 @@ import { drawCardDetail } from '@/view/cardDetail';
 import { drawCardList } from '@/view/cardList';
 import { isInteger, isServerList, listToBase64 } from '@/routers/utils';
 import { fuzzySearch } from '@/routers/fuzzySearch';
-import { Server } from '@/types/Server';
+import { getServerByServerId, Server } from '@/types/Server';
 
 const router = express.Router();
 
@@ -43,6 +43,9 @@ export async function commandCard(default_servers: Server[], text: string, useEa
     console.log(fuzzySearchResult)
     if (Object.keys(fuzzySearchResult).length == 0) {
         return ['错误: 没有有效的关键词']
+    }
+    for(let i = 0; i < default_servers.length; i++) {
+        default_servers[i] = getServerByServerId(default_servers[i])
     }
     return await drawCardList(fuzzySearchResult, default_servers, compress)
 

--- a/backend/src/routers/searchCharacter.ts
+++ b/backend/src/routers/searchCharacter.ts
@@ -4,7 +4,7 @@ import { drawCharacterList } from '@/view/characterList';
 import { drawCharacterDetail } from '@/view/characterDetail';
 import { isInteger } from '@/routers/utils';
 import { fuzzySearch } from '@/routers/fuzzySearch';
-import { Server } from '@/types/Server';
+import { getServerByServerId, Server } from '@/types/Server';
 import { listToBase64, isServerList } from '@/routers/utils';
 
 const router = express.Router();
@@ -41,6 +41,9 @@ export async function commandCharacter(default_servers: Server[], text: string, 
     console.log(fuzzySearchResult)
     if (Object.keys(fuzzySearchResult).length == 0) {
         return ['错误: 没有有效的关键词']
+    }
+    for(let i = 0; i < default_servers.length; i++) {
+        default_servers[i] = getServerByServerId(default_servers[i])
     }
     return await drawCharacterList(fuzzySearchResult, default_servers, compress)
 

--- a/backend/src/routers/searchEvent.ts
+++ b/backend/src/routers/searchEvent.ts
@@ -2,7 +2,7 @@ import { isInteger } from '@/routers/utils';
 import { fuzzySearch } from '@/routers/fuzzySearch';
 import { drawEventDetail } from '@/view/eventDetail';
 import { drawEventList } from '@/view/eventList';
-import { Server } from '@/types/Server';
+import { getServerByServerId, Server } from '@/types/Server';
 import { listToBase64, isServerList } from '@/routers/utils';
 import express from 'express';
 import { validationResult, body } from 'express-validator';
@@ -44,6 +44,9 @@ export async function commandEvent(default_servers: Server[], text: string, useE
     console.log(fuzzySearchResult)
     if (Object.keys(fuzzySearchResult).length == 0) {
         return ['错误: 没有有效的关键词']
+    }
+    for(let i = 0; i < default_servers.length; i++) {
+        default_servers[i] = getServerByServerId(default_servers[i])
     }
     return await drawEventList(fuzzySearchResult, default_servers, compress)
 

--- a/backend/src/routers/searchGacha.ts
+++ b/backend/src/routers/searchGacha.ts
@@ -1,6 +1,6 @@
 import { body, validationResult } from 'express-validator';
 import { drawGachaDetail } from '@/view/gachaDetail';
-import { Server } from '@/types/Server';
+import { getServerByServerId, Server } from '@/types/Server';
 import { listToBase64, isServerList } from '@/routers/utils';
 import express from 'express';
 
@@ -31,9 +31,12 @@ router.post('/', [
     }
 });
 
-export async function commandGacha(default_server: Server[], gachaId: number, useEasyBG: boolean, compress: boolean): Promise<Array<Buffer | string>> {
-
-    return await drawGachaDetail(gachaId, default_server, useEasyBG, compress)
+export async function commandGacha(default_servers: Server[], gachaId: number, useEasyBG: boolean, compress: boolean): Promise<Array<Buffer | string>> {
+    
+    for(let i = 0; i < default_servers.length; i++) {
+        default_servers[i] = getServerByServerId(default_servers[i])
+    }
+    return await drawGachaDetail(gachaId, default_servers, useEasyBG, compress)
 
 }
 

--- a/backend/src/routers/searchPlayer.ts
+++ b/backend/src/routers/searchPlayer.ts
@@ -9,7 +9,7 @@ const router = express.Router();
 
 router.post('/', [
     body('playerId').isInt(), // Validation for 'playerId' field
-    body('server').custom((value) => isServer(value)), // Custom validation for 'server' field
+    body('server').custom(isServer), // Custom validation for 'server' field
     body('useEasyBG').isBoolean(), // Validation for 'useEasyBG' field
     body('compress').optional().isBoolean(),
 ], async (req, res) => {

--- a/backend/src/routers/searchSong.ts
+++ b/backend/src/routers/searchSong.ts
@@ -5,7 +5,7 @@ import { fuzzySearch } from '@/routers/fuzzySearch';
 import { isInteger, listToBase64, isServerList } from '@/routers/utils';
 import { drawSongDetail } from '@/view/songDetail';
 import { Song } from '@/types/Song';
-import { Server } from '@/types/Server';
+import { getServerByServerId, Server } from '@/types/Server';
 
 const router = express.Router();
 
@@ -49,6 +49,10 @@ export async function commandSong(default_servers: Server[], text: string, compr
     console.log(fuzzySearchResult)
     if (Object.keys(fuzzySearchResult).length == 0) {
         return ['错误: 没有有效的关键词']
+    }
+    
+    for(let i = 0; i < default_servers.length; i++) {
+        default_servers[i] = getServerByServerId(default_servers[i])
     }
     return await drawSongList(fuzzySearchResult, default_servers, compress)
 }

--- a/backend/src/routers/songChart.ts
+++ b/backend/src/routers/songChart.ts
@@ -5,7 +5,7 @@ import { fuzzySearch } from '@/routers/fuzzySearch';
 import { isInteger, listToBase64, isServerList } from '@/routers/utils';
 import { drawSongChart } from '@/view/songChart';
 import { Song } from '@/types/Song';
-import { Server } from '@/types/Server';
+import { getServerByServerId, Server } from '@/types/Server';
 
 const router = express.Router();
 
@@ -47,6 +47,9 @@ export async function commandSongChart(default_servers: Server[], songId: number
     console.log(fuzzySearchResult)
     if (fuzzySearchResult.difficulty === undefined) {
         return ['错误: 不正确的难度关键词,可以使用以下关键词:easy,normal,hard,expert,special']
+    }
+    for(let i = 0; i < default_servers.length; i++) {
+        default_servers[i] = getServerByServerId(default_servers[i])
     }
     return await drawSongChart(songId, parseInt(fuzzySearchResult.difficulty[0]), default_servers, compress)
 }

--- a/backend/src/routers/songMeta.ts
+++ b/backend/src/routers/songMeta.ts
@@ -32,6 +32,9 @@ router.post('/', [
 });
 
 export async function commandSongMeta(default_servers: Server[], server: Server, compress:boolean): Promise<Array<Buffer | string>> {
+    for(let i = 0; i < default_servers.length; i++) {
+        default_servers[i] = getServerByServerId(default_servers[i])
+    }
     if (server == undefined) {
         server = default_servers[0]
     }

--- a/backend/src/routers/utils.ts
+++ b/backend/src/routers/utils.ts
@@ -16,7 +16,7 @@ export function isInteger(char: string): boolean {
 
 export function isServer(server: any): boolean {
     if (typeof server == 'number') {
-        server = server.toString()
+        server = Server[server]
     }
     return Object.keys(Server).includes(server)
 }

--- a/backend/src/routers/ycx.ts
+++ b/backend/src/routers/ycx.ts
@@ -11,7 +11,7 @@ const router = express.Router();
 router.post(
     '/',
     [
-        body('server').custom(value => isServer(value)),
+        body('server').custom(isServer),
         body('tier').isInt(),
         body('eventId').optional().isInt(),
         body('compress').optional().isBoolean(),

--- a/backend/src/routers/ycxAll.ts
+++ b/backend/src/routers/ycxAll.ts
@@ -1,7 +1,7 @@
 import { drawCutoffListOfEvent } from '@/view/cutoffListOfEvent';
 import { Server, getServerByServerId } from '@/types/Server';
 import { getPresentEvent } from '@/types/Event';
-import { listToBase64, isServerList } from '@/routers/utils';
+import { listToBase64, isServerList,isServer } from '@/routers/utils';
 import express from 'express';
 import { body, validationResult } from 'express-validator';
 
@@ -10,7 +10,7 @@ const router = express.Router();
 router.post(
     '/',
     [
-        body('server').custom((value) => isServerList(value)), // Custom validation using isServerList
+        body('server').custom((value) => isServer(value)), // Custom validation using isServerList
         body('eventId').optional().isInt(), // eventId is optional and must be an integer if provided
         body('compress').optional().isBoolean(),
     ],

--- a/backend/src/types/Server.ts
+++ b/backend/src/types/Server.ts
@@ -11,11 +11,10 @@ export enum Server {
 }
 
 export function getServerByServerId (serverId: number): Server {
-    //如果是string,转换为number
+    //如果是string，则按服务器名查服务器
     if (typeof serverId == 'string') {
-        serverId = Number(serverId)
+        serverId = getServerByName(serverId)
     }
-    //
     // 根据服务器id获取对应服务器
     return serverList[serverId]
 }

--- a/backend/src/view/cutoffListOfEvent.ts
+++ b/backend/src/view/cutoffListOfEvent.ts
@@ -10,9 +10,7 @@ import { Cutoff } from "@/types/Cutoff";
 import { drawCutoffChart } from '@/components/chart/cutoffChart'
 import { serverNameFullList, tierListOfServer } from '@/config';
 import { drawEventDatablock } from '@/components/dataBlock/event';
-import { drawTips } from '@/components/tips'
-import { assetsRootPath, statusName } from '@/config';
-import * as path from 'path'
+import { statusName } from '@/config';
 
 
 
@@ -26,7 +24,7 @@ export async function drawCutoffListOfEvent(eventId: number, server: Server, com
     }
     var all = []
     all.push(drawTitle('档线列表', `${serverNameFullList[server]}`))
-    all.push(await drawEventDatablock(event[server]))
+    all.push(await drawEventDatablock(event,[server]))
 
     const list: Array<Image | Canvas> = []
 


### PR DESCRIPTION
修正了routers中对传入 server/server mode/default servers 参数的解析逻辑
现在对于 **server** 和 **server mode** 支持 **0 1 2 3 4** 或 **"cn" "jp"** 类的形式
对于 **default servers** 支持 **[ "cn", "jp" ]** 或 **[ 0, 1 ]** 类的形式
同时修复了ycxAll中一处参数传递错误引起的ycxAll报错