### PR TITLE
feat(backend): add npm start script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,9 @@
     "assets"
   ],
   "license": "MIT",
-  "scripts": {},
+  "scripts": {
+    "start": "ts-node -r tsconfig-paths/register src/app.ts"
+  },
   "keywords": [
     "chatbot",
     "koishi",
@@ -45,6 +47,7 @@
     "skia-canvas": "^1.0.2",
     "sqlite3": "^5.1.7",
     "svg2img": "^1.0.0-beta.2",
+    "ts-node": "^10.9.2",
     "validator": "^13.9.0",
     "xlsx": "^0.18.5"
   },


### PR DESCRIPTION
在backend的`package.json`中加入`npm start`脚本，以及`ts-node`依赖。
从而linux下`git clone`后`backend/`可通过命令行`npm install && npm start`运行服务器
已于node18(debian,ubantu)、20(archwiki)下测试至`[maindll] mainAPI loaded`输出（node22、23在`npm install`的canvas时失败）