### PR TITLE
chore(deps): remove unused backend dependency sqlite3

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -44,7 +44,6 @@
     "moment": "^2.30.1",
     "mongodb": "^6.6.2",
     "skia-canvas": "^1.0.2",
-    "sqlite3": "^5.1.7",
     "svg2img": "^1.0.0-beta.2",
     "ts-node": "^10.9.2",
     "validator": "^13.9.0",


### PR DESCRIPTION
从后端的`package.json`中移除没有被用到的依赖`sqlite3`
同时这避免了sqlite3导致的在node >= 22且python >= 3.12环境下运行`npm install`失败的情况

在`koishi`的沙盒中粗略测试了` ycm ycx 查卡 查曲 查玩家 `命令，目测大致正确