### PR TITLE
chore(backend): use local ts-node via npx in pm2 script

### DIFF
--- a/backend/ecosystem.config.js
+++ b/backend/ecosystem.config.js
@@ -2,8 +2,8 @@ module.exports = {
     apps: [
       {
         name: 'tsugu-backend',
-        script: 'ts-node',
-        args: '--transpile-only -r tsconfig-paths/register src/app.ts',
+        script: 'npx',
+        args: 'ts-node --transpile-only -r tsconfig-paths/register src/app.ts',
         interpreter: 'none',
         exec_mode: 'fork',
         instances: 1,


### PR DESCRIPTION
将pm2的`ecosystem`配置文件的启动脚本改为用`npx`调用本地`ts-node`
不需要再全局安装`ts-node`

在`koishi`的沙盒中粗略测试了`ycm ycx 查卡 查曲 查玩家`命令，目测大致正确
